### PR TITLE
[Chore/#64] 캘린더 첫 실행시 현재 주간 시작 날짜가 잘못된 버그 수정

### DIFF
--- a/SafeArea/SafeArea/Model/WeekStore.swift
+++ b/SafeArea/SafeArea/Model/WeekStore.swift
@@ -108,7 +108,7 @@ class WeekStore: ObservableObject {
         let startOfWeek = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: today))!
 
         currentWeek.removeAll()
-        (0..<7).forEach { day in
+        (1...7).forEach { day in
             if let weekday = calendar.date(byAdding: .day, value: day, to: startOfWeek) {
                 currentWeek.append(weekday)
             }


### PR DESCRIPTION
## 🎀 Related Issues

#### close #64

## 🤔 What Did You Do
- [x] 캘린더 첫 실행시 현재 주간 시작 날짜가 잘못된 버그 수정
